### PR TITLE
fix: ensure clean logging and result paths

### DIFF
--- a/encodeval/eval_tasks/abstract_eval.py
+++ b/encodeval/eval_tasks/abstract_eval.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from dataclasses import dataclass
 import subprocess
 from typing import Callable, Dict, Literal
@@ -154,9 +155,10 @@ class EvalConfig:
         self.tr_args.logging_dir = f"{os.environ['EVAL_MODEL_PATH']}/evaluation/logs/{output_subdir}"
         self.results_dir = f"{output_dir}/{model_name}/{output_subdir}"
 
-        # Clear old logs if logging directory is not empty
-        if os.path.exists(self.tr_args.logging_dir) and len(os.listdir(self.tr_args.logging_dir)) > 0:
-            subprocess.run(f"rm {self.tr_args.logging_dir}/*", shell=True, check=True)
+        # Clear old logs if logging directory already exists
+        if os.path.exists(self.tr_args.logging_dir):
+            shutil.rmtree(self.tr_args.logging_dir, ignore_errors=True)
+        os.makedirs(self.tr_args.logging_dir, exist_ok=True)
 
     def load_model(self):
         """

--- a/launch_xp_eval.py
+++ b/launch_xp_eval.py
@@ -86,16 +86,18 @@ def create_selective_cleanup_command(model, task_abbrev, dataset_name, lr_value)
     """Create selective cleanup commands for FORCE_OVERWRITE"""
     if not FORCE_OVERWRITE:
         return "# No cleanup - FORCE_OVERWRITE is disabled"
-    
-    lr_str = lr_value.replace('.', '_').replace('-', '_').replace('+', 'p')
-    model_ft = f"{model}_ftlr_{lr_str}"
-    path = f"./results/main/{model_ft}/{task_abbrev}/{dataset_name}"
-    
+    model_path = os.path.join(MODEL_PATH, model)
+    results_path = f"./results/main/{model}/{task_abbrev}/{dataset_name}"
+    weights_path = f"{model_path}/evaluation/weights/{task_abbrev}/{dataset_name}"
+    logs_path = f"{model_path}/evaluation/logs/{task_abbrev}/{dataset_name}"
+
     return f"""
 # FORCE_OVERWRITE: Cleanup of existing results, logs, and weights
 echo "Performing cleanup for {dataset_name} with LR={lr_value}..."
 
-rm -rf "{path}" 2>/dev/null || true
+rm -rf "{results_path}" 2>/dev/null || true
+rm -rf "{weights_path}" 2>/dev/null || true
+rm -rf "{logs_path}" 2>/dev/null || true
 
 echo "Cleanup completed for {dataset_name} (task: {task_abbrev}, lr: {lr_value})"
 """


### PR DESCRIPTION
## Summary
- make logging cleanup robust by using `shutil.rmtree` and recreating logging dir
- expand FORCE_OVERWRITE cleanup to remove stale logs, weights, and results

## Testing
- `python -m py_compile encodeval/eval_tasks/abstract_eval.py launch_xp_eval.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03487b1e88333a24e8fa03eac3269